### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## v1.0.1 - 2019-09-17
 
 ### Added
 
-* Dark mode for default theme (there's an option in `index.php`)
+* Dark mode for default theme (hint: there's an option in `index.php`)
 * Media endpoint URL in HTML head section (in addition to micropub query)
 
 ### Fixed
 
 * Uses current time if `published` value is an empty string on micropub API
 * Properly escape values for meta tags in HTML head
-* Prevent errors from occurring when trying to determine non-existent Content
-  Type.
+* Prevent errors from occurring when trying to determine non-existent
+  Content-Type
+* Wrap long words and links in default theme
+* Save user configuration propertly if note and links are empty
+
+### Changed
+
+* Resize profile to always be square
 
 ## v1.0.0 Initial Release - 2019-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+* Dark mode for default theme (there's an option in `index.php`)
+* Media endpoint URL in HTML head section (in addition to micropub query)
+
+### Fixed
+
+* Uses current time if `published` value is an empty string on micropub API
+* Properly escape values for meta tags in HTML head
+* Prevent errors from occurring when trying to determine non-existent Content
+  Type.
+
+## v1.0.0 Initial Release - 2019-09-14
+
+No changes were made. It was the first release, after all!

--- a/includes/api.include.php
+++ b/includes/api.include.php
@@ -91,6 +91,7 @@ function ml_api_post_json ($post, $key, $is_single = false) {
 	if (!is_array($post)) return null;
 	if (!isset($post[$key])) return null;
 	if (empty($post[$key])) return null;
+	if (!is_array($post[$key])) return $post[$key];
 
 	// A lot of microformats2 items are intentionally single element arrays.
 	// I'm not sure why, but if we know it's supposed to, parse it here.

--- a/includes/functions.include.php
+++ b/includes/functions.include.php
@@ -418,6 +418,7 @@ function ml_page_headers () {
 
 	<title><?php echo ml_get_title(); ?></title>
 	<link rel='micropub' href='<?php echo ml_base_url() . 'micropub/index.php'; ?>' />
+	<link rel="micropub_media" href='<?php echo ml_base_url() . 'media/index.php'; ?>' />
 	<link rel='authorization_endpoint' href='<?php echo Config::INDIEAUTH_PROVIDER; ?>' />
 	<link rel='token_endpoint' href='<?php echo Config::INDIEAUTH_TOKEN_ENDPOINT; ?>' />
 	<link rel='icon' href='<?php echo $image; ?>' />

--- a/includes/functions.include.php
+++ b/includes/functions.include.php
@@ -244,7 +244,7 @@ function ml_get_title () {
 	$str = '';
 
 	if ($showing === Show::POST || $showing === Show::PAGE) {
-		$str .= $posts['name'] !== ''
+		$str .= $posts['name'] !== '' && $posts['name'] !== null
 			? $posts['name']
 			: $posts['summary'];
 		$str .= Config::TITLE_SEPARATOR;
@@ -395,6 +395,9 @@ function ml_page_headers () {
 		$description = User::NOTE;
 		$image = ml_icon_url();
 	}
+
+	$description = htmlspecialchars($description, ENT_QUOTES);
+	$title = htmlspecialchars(ml_get_title(), ENT_QUOTES);
 	?>
 	<meta name='description' content='<?php echo $description; ?>' />
 	<meta name='generator' content='Microlight <?php echo MICROLIGHT; ?>' />
@@ -404,7 +407,7 @@ function ml_page_headers () {
 	<?php if (Config::OPEN_GRAPH === true): ?>
 	<meta name='twitter:card' content='summary' />
 	<meta property='og:url' content='<?php echo ml_canonical_permalink(); ?>' />
-	<meta property='og:title' content='<?php echo ml_get_title(); ?>' />
+	<meta property='og:title' content='<?php echo $title; ?>' />
 	<meta property='og:description' content='<?php echo $description; ?>' />
 	<meta property='og:image' content='<?php echo $image; ?>' />
 	<?php endif; ?>

--- a/index.php
+++ b/index.php
@@ -1,7 +1,7 @@
 <?php
 
 // This definition will prevent any files to be loaded outside of this file.
-define('MICROLIGHT', 'v1.0.0');
+define('MICROLIGHT', 'v1.0.1');
 
 try {
 	// Load user details

--- a/install.php
+++ b/install.php
@@ -73,12 +73,10 @@ class User {
 	const EMAIL = \'' . $email .'\';
 ';
 
-	// Add note, if provided
-	if (!empty($note)) {
-		$note = quote($note);
-		$contents .= '	const NOTE = \'' . $note . '\';
+	// Always add note, even if it's empty.
+	$note = quote($note);
+	$contents .= '	const NOTE = \'' . $note . '\';
 ';
-	}
 
 	// Open identities section, even if there are no identities provided
 	$contents .= '	const IDENTITIES = [
@@ -96,7 +94,8 @@ class User {
 ';
 		}
 	} else {
-		$contents .= '		//	[ \'name\' => \'\', \'url\' => \'\' ],';
+		$contents .= '		//	[ \'name\' => \'\', \'url\' => \'\' ],
+';
 	}
 
 	// Close identities section

--- a/install.php
+++ b/install.php
@@ -148,7 +148,12 @@ if (isset($_POST['submit'])) {
 
 		// Attempt to upload/resize profile picture
 		if (isset($_FILES['photo'])) {
-			$image = new ImageResizer($_FILES['photo'], 'me', 'image/jpg');
+			$image = new ImageResizer(
+				$_FILES['photo'],
+				'me',
+				ImageType::JPG,
+				ImageResizeMethod::SQUARE
+			);
 		}
 
 		if (count($errors) === 0) {

--- a/install.php
+++ b/install.php
@@ -1,7 +1,7 @@
 <?php
 
 // This definition will prevent any files to be loaded outside of this file.
-define('MICROLIGHT', 'v1.0.0');
+define('MICROLIGHT', 'v1.0.1');
 
 session_start();
 require_once('includes/config.php');

--- a/media/index.php
+++ b/media/index.php
@@ -1,6 +1,6 @@
 <?php
 
-define('MICROLIGHT', 'v1.0.0');
+define('MICROLIGHT', 'v1.0.1');
 
 chdir('..');
 require_once('includes/config.php');

--- a/micropub/index.php
+++ b/micropub/index.php
@@ -1,6 +1,6 @@
 <?php
 
-define('MICROLIGHT', 'v1.0.0');
+define('MICROLIGHT', 'v1.0.1');
 
 chdir('..');
 require_once('includes/config.php');
@@ -40,6 +40,13 @@ try {
 
 		case 'source':
 			ml_http_response(HTTPStatus::OK, query_source());
+			return;
+
+		default:
+			ml_http_error(
+				HTTPStatus::INVALID_REQUEST,
+				'Invalid q parameter. Pick one of "config", "syndicate-to", or "source"'
+			);
 			return;
 		}
 

--- a/micropub/post/lib.php
+++ b/micropub/post/lib.php
@@ -9,7 +9,7 @@ if (!defined('MICROLIGHT')) die();
  * @return string|false Return the date in ISO8601 if valid, otherwise false
  */
 function validate_date ($date) {
-	if ($date === null) {
+	if ($date === null || $date === '') {
 		// Use the current timestamp, if not provided.
 		return gmdate("c");
 	} else {
@@ -87,7 +87,7 @@ function generate_slug ($name, $summary) {
 /**
  * Determines the post type depending on whether other optional fields to POST
  * were provided.
- * 
+ *
  * @param PostEntry $entry
  * @return array|false If a valid post type was detected, an array containing
  *                     "type" and "url" keys, otherwise false.

--- a/themes/microlight-default/css/style-dark.css
+++ b/themes/microlight-default/css/style-dark.css
@@ -1,0 +1,254 @@
+* {
+	margin: 0;
+	padding: 0;
+	box-sizing: border-box;
+}
+
+body {
+	background-color: #111;
+	color: #eee;
+	max-width: 640px;
+	width: 100%;
+	margin: 0 auto;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
+a {
+	color: #ccc;
+	text-decoration: none;
+}
+
+a:hover {
+	text-decoration: underline;
+	color: #ff4700;
+}
+
+h1, h2, h3, h4, h5, h6 {
+	line-height: 1.1;
+	/* https://www.client9.com/css-system-font-stack-serif-medium-v1/ */
+	/* font-family: "Iowan Old Style", "Palatino Linotype", Palatino, "URW Palladio L", serif; */
+}
+
+p, .e-content, img {
+	line-height: 20px;
+	margin-bottom: 10px;
+}
+
+ul {
+	margin-left: 24px;
+}
+
+header {
+	padding: 32px 32px 16px;
+	max-width: 640px;
+	margin: 0 auto;
+}
+
+header .u-photo {
+	float: left;
+	width: 160px;
+	margin-right: 16px;
+	border-radius: 50%;
+}
+
+.p-note {
+	margin-top: 16px;
+}
+
+h2.p-name {
+	font-size: 24px;
+}
+
+.p-name-emoji {
+	margin-right: 12px;
+	line-height: 20px;
+	height: 20px;
+	font-size: 20px;
+	-moz-user-select: none;
+	-webkit-user-select: none;
+	user-select: none;
+}
+
+.me-links {
+	list-style-type: none;
+	margin-left: 0;
+	margin-top: 16px;
+}
+.me-links li {
+	display: inline-block;
+	margin-right: 12px;
+}
+.me-links li:not(:last-child):after {
+	content: '';
+	width: 12px;
+	margin-left: 12px;
+	border-top: 1px solid #666;
+	display: inline-block;
+	vertical-align: middle;
+}
+
+article {
+	padding: 32px;
+}
+
+article h2 {
+	margin-bottom: 16px;
+}
+
+.page article h2 {
+	font-weight: 700;
+	font-style: italic;
+	font-size: 28pt;
+	margin-bottom: 16px;
+}
+
+.page article .e-content {
+	font-size: 12pt;
+	line-height: 1.618;
+	margin-bottom: 16px;
+}
+
+.dt-published-link, .dt-updated, #entry-interactions .dt-published {
+	display: block;
+	color: #999;
+	text-decoration: none;
+	font-size: 11pt;
+	font-weight: 500;
+	margin-bottom: 4px;
+}
+
+.h-geo, .h-adr {
+	margin-top: 12px;
+	margin-bottom: 16px;
+}
+
+img {
+	max-width: 100%;
+}
+
+audio {
+	width: 100%;
+}
+
+.tags {
+	text-align: right;
+	float: right;
+	font-size: 11pt;
+	max-width: 50%;
+}
+
+.tags a {
+	font-weight: 700;
+	color: #ccc;
+	text-decoration: none;
+	text-transform: lowercase;
+	margin-left: 6px;
+}
+
+.tags a:before {
+	content: '#';
+	color: #666;
+}
+
+.pagination {
+	display: block;
+	padding: 32px;
+}
+.pagination:after {
+	clear: both;
+	content: '';
+	float: none;
+	display: block;
+}
+
+.pagination-left, .pagination-right {
+	width: 50%;
+	width: calc(50% - 8px);
+	display: inline-block;
+	padding: 16px;
+	text-align: center;
+	border-radius: 8px;
+	text-decoration: none;
+	border: 1px solid #191919;
+	font-weight: 700;
+}
+
+.pagination-left:hover, .pagination-right:hover {
+	background-color: #191919;
+}
+
+.pagination-left {
+	float: left;
+}
+
+.pagination-right {
+	float: right;
+}
+
+.hidden {
+	display: none;
+}
+
+#entry-interactions {
+	padding-top: 40px;
+}
+
+#entry-interactions:empty {
+	display: none;
+}
+
+#entry-interactions::before {
+	content: 'INTERACTIONS';
+	color: #666;
+	font-weight: 700;
+}
+
+#entry-interactions > div {
+	padding: 10px 16px;
+	border: 1px solid #333;
+	border-radius: 6px;
+	margin-top: 10px;
+}
+
+#entry-interactions .p-name {
+	font-weight: 700;
+}
+
+.entry-interaction-emoji, #entry-interactions .u-photo {
+	float: left;
+	line-height: 40px;
+	width: 40px;
+	height: 40px;
+	font-size: 40px;
+	margin-right: 10px;
+	-moz-user-select: none;
+	-webkit-user-select: none;
+	user-select: none;
+}
+
+@media (max-width: 500px) {
+	header .u-photo {
+		float: none;
+		display: block;
+		width: 100%;
+		max-width: 240px;
+		margin: 0 auto 16px auto;
+	}
+
+	header {
+		text-align: center;
+	}
+
+	.tags {
+		text-align: left;
+		float: none;
+		display: block;
+		margin-bottom: 10px;
+		max-width: 100%;
+	}
+	.tags a {
+		display: inline-block;
+		margin: 0 5px 0 0;
+		padding: 0 0 5px 0;
+	}
+}

--- a/themes/microlight-default/css/style-dark.css
+++ b/themes/microlight-default/css/style-dark.css
@@ -59,6 +59,11 @@ h2.p-name {
 	font-size: 24px;
 }
 
+h2.p-name, h2.p-name a {
+	word-break: normal;
+	overflow-wrap: break-word;
+}
+
 .p-name-emoji {
 	margin-right: 12px;
 	line-height: 20px;

--- a/themes/microlight-default/css/style.css
+++ b/themes/microlight-default/css/style.css
@@ -57,6 +57,11 @@ h2.p-name {
 	font-size: 24px;
 }
 
+h2.p-name, h2.p-name a {
+	word-break: normal;
+	overflow-wrap: break-word;
+}
+
 .p-name-emoji {
 	margin-right: 12px;
 	line-height: 20px;

--- a/themes/microlight-default/elements.php
+++ b/themes/microlight-default/elements.php
@@ -9,7 +9,7 @@ function html_head () {
 
 	echo "<head>";
 		echo "<meta charset='UTF-8' />";
-		echo "<meta name='viewport' content='width=device-width, initial-scale=1.0' />";
+		echo "<meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0' />";
 		echo "<meta http-equiv='X-UA-Compatible' content='ie=edge' />";
 
 		// Add pre-generated headers

--- a/themes/microlight-default/elements.php
+++ b/themes/microlight-default/elements.php
@@ -5,6 +5,8 @@
 if (!defined('MICROLIGHT')) die();
 
 function html_head () {
+	global $dark_mode;
+
 	echo "<head>";
 		echo "<meta charset='UTF-8' />";
 		echo "<meta name='viewport' content='width=device-width, initial-scale=1.0' />";
@@ -13,10 +15,14 @@ function html_head () {
 		// Add pre-generated headers
 		ml_page_headers();
 
+		$css = isset($dark_mode) && $dark_mode === true
+			? '/css/style-dark.css'
+			: '/css/style.css';
+
 		// Add this theme's stylesheet
 		echo "<link rel='stylesheet' href='";
 		echo ml_get_theme_dir();
-		echo "/css/style.css' />";
+		echo $css . "' />";
 	echo "</head>";
 }
 

--- a/themes/microlight-default/index.php
+++ b/themes/microlight-default/index.php
@@ -5,7 +5,7 @@
 if (!defined('MICROLIGHT')) die();
 
 // Should this theme be dark or light? You decide!
-$dark_mode = true;
+$dark_mode = false;
 
 // Contains various elements for this page
 require_once('elements.php');

--- a/themes/microlight-default/index.php
+++ b/themes/microlight-default/index.php
@@ -4,6 +4,9 @@
 // file from within microlight itself.
 if (!defined('MICROLIGHT')) die();
 
+// Should this theme be dark or light? You decide!
+$dark_mode = true;
+
 // Contains various elements for this page
 require_once('elements.php');
 

--- a/webmention/index.php
+++ b/webmention/index.php
@@ -1,6 +1,6 @@
 <?php
 
-define('MICROLIGHT', 'v1.0.0');
+define('MICROLIGHT', 'v1.0.1');
 
 chdir('..');
 require_once('includes/config.php');


### PR DESCRIPTION
## v1.0.1 - 2019-09-17

### Added

* Dark mode for default theme (hint: there's an option in `index.php`)
* Media endpoint URL in HTML head section (in addition to micropub query)

### Fixed

* Uses current time if `published` value is an empty string on micropub API
* Properly escape values for meta tags in HTML head
* Prevent errors from occurring when trying to determine non-existent Content-Type
* Wrap long words and links in default theme
* Save user configuration propertly if note and links are empty

### Changed

* Resize profile to always be square
